### PR TITLE
Patch/global vars issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# caf-component-aws-pipelines
+# caf-component-azure-pipelines
 
 ---
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# caf-component-azure-pipelines
+# caf-component-aws-pipelines
 
 ---
 ## Introduction

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/common/scripts/global/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/common/scripts/global/pipeline/common/functions.sh
@@ -199,7 +199,9 @@ function codebuild_status {
 }
 
 function set_global_vars {
-    if [ -n "$SOURCE_REPO_URL" ]; then
+    if [ -z "$SOURCE_REPO_URL" ]; then
+        echo "SOURCE_REPO_URL not found: ${SOURCE_REPO_URL}"
+    else
         protocol="${SOURCE_REPO_URL%%://*}://"
         domain="${SOURCE_REPO_URL#*://}"
         base="${domain%%/*}"

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/common/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/common/scripts/local/pipeline/common/functions.sh
@@ -148,7 +148,7 @@ function assume_iam_role {
     local region=$3
 
     echo "Assuming the IAM deployment role"
-    sts_creds=$(aws sts assume-role --role-arn "$role_arn" --role-session-name CodeBuildTerragruntDeployCrossAccountRole)
+    sts_creds=$(aws sts assume-role --role-arn "$role_arn" --role-session-name caf-build-agent)
     access_key=$(echo "${sts_creds}" | jq -r '.Credentials.AccessKeyId')
     secret_access_key=$(echo "${sts_creds}" | jq -r '.Credentials.SecretAccessKey')
     session_token=$(echo "${sts_creds}" | jq -r '.Credentials.SessionToken')

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/global/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/global/pipeline/common/functions.sh
@@ -46,5 +46,3 @@ function tag_container {
     local version_tag=$(run_launch_github_version_predict "${FROM_BRANCH}")
     add_ecr_image_tag "${version_tag}" "${MERGE_COMMIT_ID}" "${GIT_REPO}"
 }
-
-add_ecr_image_tag "1.0.0" "0.1.0" "caf-build-agent"

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/global/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/global/pipeline/common/functions.sh
@@ -28,8 +28,7 @@ function build_container {
     tool_versions_install "${CODEBUILD_SRC_DIR}/${GIT_REPO%"${PROPERTIES_REPO_SUFFIX}"}"
     assume_iam_role "${ROLE_TO_ASSUME}" "${TARGETENV}" "${AWS_REGION}"
     set_netrc "${GIT_SERVER_URL}" "${GIT_USERNAME}" "${GIT_TOKEN}"
-    make_docker_build "${MERGE_COMMIT_ID}" "${DOCKER_BUILD_ARCH}"
-}
+    make_docker_build "${MERGE_COMMIT_ID}"
 
 function push_container {
     start_docker
@@ -39,7 +38,7 @@ function push_container {
     tool_versions_install "${CODEBUILD_SRC_DIR}/${GIT_REPO%"${PROPERTIES_REPO_SUFFIX}"}"
     assume_iam_role "${ROLE_TO_ASSUME}" "${TARGETENV}" "${AWS_REGION}"
     set_netrc "${GIT_SERVER_URL}" "${GIT_USERNAME}" "${GIT_TOKEN}"
-    make_docker_push "${MERGE_COMMIT_ID}" "${DOCKER_BUILD_ARCH}"
+    make_docker_push "${MERGE_COMMIT_ID}"
 }
 
 function tag_container {    
@@ -47,3 +46,5 @@ function tag_container {
     local version_tag=$(run_launch_github_version_predict "${FROM_BRANCH}")
     add_ecr_image_tag "${version_tag}" "${MERGE_COMMIT_ID}" "${GIT_REPO}"
 }
+
+add_ecr_image_tag "1.0.0" "0.1.0" "caf-build-agent"

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/global/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/global/pipeline/common/functions.sh
@@ -43,7 +43,12 @@ function push_container {
 }
 
 function tag_container {    
-    set_vars_from_script "${CODEBUILD_SRC_DIR}/set_vars.sh"
+    install_asdf "${HOME}"
+    set_vars_script_and_clone_service
+    git_checkout "${MERGE_COMMIT_ID}" "${CODEBUILD_SRC_DIR}/${GIT_REPO}"
+    tool_versions_install "${CODEBUILD_SRC_DIR}/${GIT_REPO%"${PROPERTIES_REPO_SUFFIX}"}"
+    set_netrc "${GIT_SERVER_URL}" "${GIT_USERNAME}" "${GIT_TOKEN}"
+    run_make_configure
     local version_tag=$(run_launch_github_version_predict "${FROM_BRANCH}")
     add_ecr_image_tag "${version_tag}" "${MERGE_COMMIT_ID}" "${GIT_REPO}"
 }

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/global/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/global/pipeline/common/functions.sh
@@ -28,5 +28,5 @@ function build_container {
     tool_versions_install "${CODEBUILD_SRC_DIR}/${GIT_REPO%"${PROPERTIES_REPO_SUFFIX}"}"
     assume_iam_role "${ROLE_TO_ASSUME}" "${TARGETENV}" "${AWS_REGION}"
     set_netrc "${GIT_SERVER_URL}" "${GIT_USERNAME}" "${GIT_TOKEN}"
-    build_container_ecr "${MERGE_COMMIT_ID}"
+    build_container_ecr "${MERGE_COMMIT_ID}" "${DOCKER_BULD_ARCH}"
 }

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/global/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/global/pipeline/common/functions.sh
@@ -29,6 +29,7 @@ function build_container {
     assume_iam_role "${ROLE_TO_ASSUME}" "${TARGETENV}" "${AWS_REGION}"
     set_netrc "${GIT_SERVER_URL}" "${GIT_USERNAME}" "${GIT_TOKEN}"
     make_docker_build "${MERGE_COMMIT_ID}"
+}
 
 function push_container {
     start_docker

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
@@ -14,7 +14,7 @@ function make_docker_build {
 
     run_make_configure
     make platform/devenv/configure-docker-buildx
-    echo "Container will be built with IMAGE_TAG=$image_tag"
+    echo "Container will be built with IMAGE_TAG=$image_tag, arch_type=$arch_type"
     export DOCKER_BUILD_ARCH="${arch_type}" \
         && make docker/build
 }

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
@@ -39,6 +39,6 @@ function add_ecr_image_tag {
     local repository=$3
 
     echo "Tagging ECR image with new tag:$image_tag"
-    manifest=$(aws ecr batch-get-image --region "us-east-2" --repository-name "$repository" --image-ids imageTag=$commit_id --output json | jq --raw-output --join-output '.images[0].imageManifest')
-    aws ecr put-image --region "us-east-2" --repository-name "$repository" --image-tag "$image_tag" --image-manifest "$manifest"
+    manifest=$(aws ecr batch-get-image --repository-name "$repository" --image-ids imageTag=$commit_id --output json | jq --raw-output --join-output '.images[0].imageManifest')
+    aws ecr put-image --repository-name "$repository" --image-tag "$image_tag" --image-manifest "$manifest"
 }

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
@@ -10,26 +10,22 @@ function run_conftest_docker {
 function make_docker_build {
     local image_tag=$1
     local arch_type=$2
-    export CONTAINER_IMAGE_VERSION="${image_tag}"
 
     run_make_configure
     make platform/devenv/configure-docker-buildx
     echo "Container will be built with IMAGE_TAG=$image_tag, arch_type=$arch_type"
-    export DOCKER_BUILD_ARCH="${arch_type}" \
-        && make docker/build
+    make docker/build DOCKER_BUILD_ARCH="${arch_type}"
 }
 
 function make_docker_push {
     local image_tag=$1
     local arch_type=$2
-    export CONTAINER_IMAGE_VERSION="${image_tag}"
 
     run_make_configure
     make platform/devenv/configure-docker-buildx
     make docker/aws_ecr_login
     echo "Container will be built with IMAGE_TAG=$image_tag"
-    export DOCKER_BUILD_ARCH="${arch_type}" \
-        && make docker/push
+    make docker/push DOCKER_BUILD_ARCH="${arch_type}"
 }
 
 function start_docker {

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
@@ -10,25 +10,25 @@ function run_conftest_docker {
 function make_docker_build {
     local image_tag=$1
     local arch_type=$2
+    export CONTAINER_IMAGE_VERSION="${image_tag}"
+    export DOCKER_BUILD_ARCH="${arch_type}"
 
     run_make_configure
     make platform/devenv/configure-docker-buildx
     echo "Container will be built with IMAGE_TAG=$image_tag"
-    export CONTAINER_IMAGE_VERSION="${image_tag}"
-    export DOCKER_BUILD_ARCH="${arch_type}"
     make docker/build
 }
 
 function make_docker_push {
     local image_tag=$1
     local arch_type=$2
+    export CONTAINER_IMAGE_VERSION="${image_tag}"
+    export DOCKER_BUILD_ARCH="${arch_type}"
 
     run_make_configure
     make platform/devenv/configure-docker-buildx
     make docker/aws_ecr_login
     echo "Container will be built with IMAGE_TAG=$image_tag"
-    export CONTAINER_IMAGE_VERSION="${image_tag}"
-    export DOCKER_BUILD_ARCH="${arch_type}"
     make docker/push
 }
 

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
@@ -15,7 +15,7 @@ function make_docker_build {
     run_make_configure
     make platform/devenv/configure-docker-buildx
     echo "Container will be built with IMAGE_TAG=$image_tag, arch_type=$arch_type"
-    make docker/build DOCKER_BUILD_ARCH="${arch_type}"
+    make DOCKER_BUILD_ARCH="${arch_type}" docker/build
 }
 
 function make_docker_push {
@@ -27,7 +27,7 @@ function make_docker_push {
     make platform/devenv/configure-docker-buildx
     make docker/aws_ecr_login
     echo "Container will be built with IMAGE_TAG=$image_tag"
-    make docker/push DOCKER_BUILD_ARCH="${arch_type}"
+    make DOCKER_BUILD_ARCH="${arch_type}" docker/push
 }
 
 function start_docker {

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
@@ -16,20 +16,21 @@ function make_docker_build {
     run_make_configure
     make platform/devenv/configure-docker-buildx
     echo "Container will be built with IMAGE_TAG=$image_tag"
-    make docker/build
+    export DOCKER_BUILD_ARCH="${arch_type}" \
+        && make docker/build
 }
 
 function make_docker_push {
     local image_tag=$1
     local arch_type=$2
     export CONTAINER_IMAGE_VERSION="${image_tag}"
-    export DOCKER_BUILD_ARCH="${arch_type}"
 
     run_make_configure
     make platform/devenv/configure-docker-buildx
     make docker/aws_ecr_login
     echo "Container will be built with IMAGE_TAG=$image_tag"
-    make docker/push
+    export DOCKER_BUILD_ARCH="${arch_type}" \
+        && make docker/push
 }
 
 function start_docker {
@@ -43,6 +44,6 @@ function add_ecr_image_tag {
     local repository=$3
 
     echo "Tagging ECR image with new tag:$image_tag"
-    manifest=$(aws ecr batch-get-image --repository-name "$repository" --image-ids imageTag=$commit_id --output json | jq --raw-output --join-output '.images[0].imageManifest')
-    aws ecr put-image --repository-name "$repository" --image-tag "$image_tag" --image-manifest "$manifest"
+    manifest=$(aws ecr batch-get-image --region "us-east-2" --repository-name "$repository" --image-ids imageTag=$commit_id --output json | jq --raw-output --join-output '.images[0].imageManifest')
+    aws ecr put-image --region "us-east-2" --repository-name "$repository" --image-tag "$image_tag" --image-manifest "$manifest"
 }

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
@@ -10,6 +10,7 @@ function run_conftest_docker {
 function make_docker_build {
     local image_tag=$1
     local arch_type=$2
+    export CONTAINER_IMAGE_VERSION="${image_tag}"
 
     run_make_configure
     make platform/devenv/configure-docker-buildx
@@ -20,6 +21,7 @@ function make_docker_build {
 function make_docker_push {
     local image_tag=$1
     local arch_type=$2
+    export CONTAINER_IMAGE_VERSION="${image_tag}"
 
     run_make_configure
     make platform/devenv/configure-docker-buildx

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
@@ -15,7 +15,7 @@ function make_docker_build {
     run_make_configure
     make platform/devenv/configure-docker-buildx
     echo "Container will be built with IMAGE_TAG=$image_tag, arch_type=$arch_type"
-    make DOCKER_BUILD_ARCH="${arch_type}" docker/build
+    make docker/build
 }
 
 function make_docker_push {
@@ -27,7 +27,7 @@ function make_docker_push {
     make platform/devenv/configure-docker-buildx
     make docker/aws_ecr_login
     echo "Container will be built with IMAGE_TAG=$image_tag"
-    make DOCKER_BUILD_ARCH="${arch_type}" docker/push
+    make docker/push
 }
 
 function start_docker {

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
@@ -14,9 +14,9 @@ function make_docker_build {
     run_make_configure
     make platform/devenv/configure-docker-buildx
     echo "Container will be built with IMAGE_TAG=$image_tag"
-    export CONTAINER_IMAGE_VERSION="${image_tag}" \
-        && export DOCKER_BUILD_ARCH="${arch_type}" \
-        && make docker/build
+    export CONTAINER_IMAGE_VERSION="${image_tag}"
+    export DOCKER_BUILD_ARCH="${arch_type}"
+    make docker/build
 }
 
 function make_docker_push {
@@ -27,9 +27,9 @@ function make_docker_push {
     make platform/devenv/configure-docker-buildx
     make docker/aws_ecr_login
     echo "Container will be built with IMAGE_TAG=$image_tag"
-    export CONTAINER_IMAGE_VERSION="${image_tag}" \
-        && export DOCKER_BUILD_ARCH="${arch_type}" \
-        && make docker/push
+    export CONTAINER_IMAGE_VERSION="${image_tag}"
+    export DOCKER_BUILD_ARCH="${arch_type}"
+    make docker/push
 }
 
 function start_docker {

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
@@ -9,12 +9,15 @@ function run_conftest_docker {
 
 function build_container_ecr {
     local image_tag=$1
+    local arch_type=$2
 
     run_make_configure
     make platform/devenv/configure-docker-buildx
     make docker/aws_ecr_login
     echo "Container will be built with IMAGE_TAG=$image_tag"
-    export CONTAINER_IMAGE_VERSION="${image_tag}" && make docker/push
+    export CONTAINER_IMAGE_VERSION="${image_tag}" \
+        && export DOCKER_BULD_ARCH="${arch_type}" \
+        && make docker/push
 }
 
 function start_docker {

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
@@ -11,7 +11,6 @@ function make_docker_build {
     local image_tag=$1
     local arch_type=$2
     export CONTAINER_IMAGE_VERSION="${image_tag}"
-    export DOCKER_BUILD_ARCH="${arch_type}"
 
     run_make_configure
     make platform/devenv/configure-docker-buildx

--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/docker/scripts/local/pipeline/common/functions.sh
@@ -9,18 +9,16 @@ function run_conftest_docker {
 
 function make_docker_build {
     local image_tag=$1
-    local arch_type=$2
     export CONTAINER_IMAGE_VERSION="${image_tag}"
 
     run_make_configure
     make platform/devenv/configure-docker-buildx
-    echo "Container will be built with IMAGE_TAG=$image_tag, arch_type=$arch_type"
+    echo "Container will be built with IMAGE_TAG=$image_tag"
     make docker/build
 }
 
 function make_docker_push {
     local image_tag=$1
-    local arch_type=$2
     export CONTAINER_IMAGE_VERSION="${image_tag}"
 
     run_make_configure


### PR DESCRIPTION
- function: set_global_vars, changing SOURCE_REPO_URL to a `-z` as I was getting vbehavior where `-n` was not being recognized correctly. 
- Changing name of role-session in assumable role to a more appropriate name. 
- removing `make` vars from the CodeBuild env vars and moving them to the `Makefile.includes`. This now does not block us by the 1000 char limit. 
